### PR TITLE
fix: Only run other rules when required validates

### DIFF
--- a/src/__tests__/validator_config_tests.js
+++ b/src/__tests__/validator_config_tests.js
@@ -16,19 +16,22 @@ test('Validator should validate required rules', t => {
     notRequired: '',
   });
 
-  t.deepEqual(result, {
-    noValue: {
-      field: 'noValue',
-      rule: 'required',
-      value: null,
-      config: { required: true },
-    },
-    notInObject: {
-      field: 'notInObject',
-      rule: 'required',
-      value: undefined,
-      config: { required: true },
-    },
+  t.is(result.hasOwnProperty('notRequired'), false);
+  t.is(result.hasOwnProperty('present'), false);
+
+  t.deepEqual(result.noValue, {
+    field: 'noValue',
+    rule: 'required',
+    value: null,
+    config: { required: true },
   });
+
+  t.deepEqual(result.notInObject, {
+    field: 'notInObject',
+    rule: 'required',
+    value: undefined,
+    config: { required: true },
+  });
+
   t.deepEqual(result, validator.getErrors());
 });

--- a/src/__tests__/validator_tests.js
+++ b/src/__tests__/validator_tests.js
@@ -31,6 +31,16 @@ test('Validator.validate should filter out valid values', t => {
   t.deepEqual(validator.validate(['answer'], { answer: 42 }), {});
 });
 
+test('Validator.validateField should not run other validator rules when required fails', t => {
+  const validator = new Validator({ answer: { length: { min: 2 } } });
+  t.deepEqual(validator.validateField('answer', ''), null);
+});
+
+test('Validator.validateField should run other validator rules when required validates', t => {
+  const validator = new Validator({ answer: { length: { min: 2 } } });
+  t.deepEqual(validator.validateField('answer', '1').rule, 'length.min');
+});
+
 test('Validator.validate should accept data=undefined', t => {
   const validator = new Validator({ answer: { required: true } });
   t.deepEqual(
@@ -92,9 +102,9 @@ test('Validator.validateRule should return null when if return falsy', t => {
 test('Validator.validateRule should return "required" when if of required returns true', t => {
   const defaults = ['required', 'a', ''];
   const validator = new Validator({});
-  t.is(validator.validateRule(...defaults, { if: () => true }), 'required');
+  t.is(validator.validateRule(...defaults, { if: () => true }).rule, 'required');
   t.is(
-    validator.validateRule(...defaults, { if: ({ b }) => b === 2, values: { b: 2 } }),
+    validator.validateRule(...defaults, { if: ({ b }) => b === 2, values: { b: 2 } }).rule,
     'required'
   );
 });

--- a/src/__tests__/validator_tests.js
+++ b/src/__tests__/validator_tests.js
@@ -95,16 +95,20 @@ test('Validator.validateRule should throw UnknownRuleError when it gets an unkow
 });
 
 test('Validator.validateRule should return null when if return falsy', t => {
-  const validator = new Validator({});
-  t.is(validator.validateRule('required', 'a', '', { if: ({ b }) => b === 2 }), null);
+  const validator = new Validator({ a: { numeric: { if: ({ b }) => b === 2 } } });
+  t.is(validator.validateRule('numeric', 'a', 'dd', {}), null);
 });
 
-test('Validator.validateRule should return "required" when if of required returns true', t => {
-  const defaults = ['required', 'a', ''];
-  const validator = new Validator({});
-  t.is(validator.validateRule(...defaults, { if: () => true }).rule, 'required');
-  t.is(
-    validator.validateRule(...defaults, { if: ({ b }) => b === 2, values: { b: 2 } }).rule,
-    'required'
-  );
+test('Validator.validateRule should return "numeric" when if of numeric returns true', t => {
+  const validator = new Validator({ a: { numeric: { if: () => true } } });
+  t.is(validator.validateRule('numeric', 'a', 'dd', {}).rule, 'numeric');
 });
+
+test(
+  'Validator.validateRule should return "numeric" when if of numeric returns ' +
+  'true based on other field',
+  t => {
+    const validator = new Validator({ a: { numeric: { if: ({ b }) => b === 2 } } });
+    t.is(validator.validateRule('numeric', 'a', 'dd', { values: { b: 2 } }).rule, 'numeric');
+  }
+);

--- a/src/rules/__tests__/date_tests.js
+++ b/src/rules/__tests__/date_tests.js
@@ -3,12 +3,6 @@ import moment from 'moment';
 
 import { date } from '../date';
 
-test('rules.date should return null for empty values', t => {
-  t.is(date('field', null, { format: 'YYYY-MM-DD' }), null);
-  t.is(date('field', undefined, { format: 'YYYY-MM-DD' }), null);
-  t.is(date('field', '', { format: 'YYYY-MM-DD' }), null);
-});
-
 test('rules.date should return null for valid formats', t => {
   t.is(date('field', '2015-05-05'), null);
   t.is(date('field', '2016-02-29'), null);

--- a/src/rules/__tests__/length_tests.js
+++ b/src/rules/__tests__/length_tests.js
@@ -4,9 +4,7 @@ import { length } from '../';
 
 test('rules.length should return null accepted values', t => {
   t.is(length('field', '0', { min: 1, max: 1 }), null);
-  t.is(length('field', null, { min: 1, max: 1 }), null);
-  t.is(length('field', undefined, { min: 1, max: 1 }), null);
-  t.is(length('field', '', { min: 1, max: 1 }), null);
+  t.is(length('field', '0', { exact: 1 }), null);
 });
 
 test('rules.length should return "length.min" when value is to short', t => {

--- a/src/rules/__tests__/numeric_tests.js
+++ b/src/rules/__tests__/numeric_tests.js
@@ -31,18 +31,6 @@ test('numeric should return null for double values with custom delimiter', t => 
   t.is(numeric('field', '4,2', { delimiter: ',' }), null);
 });
 
-test('numeric should return null for empty string', t => {
-  t.is(numeric('field', ''), null);
-});
-
-test('numeric should return null for null', t => {
-  t.is(numeric('field', null), null);
-});
-
-test('numeric should return null for undefined', t => {
-  t.is(numeric('field', undefined), null);
-});
-
 test('numeric should return "numeric" letters', t => {
   t.is(numeric('field', 'not a number'), 'numeric');
 });

--- a/src/rules/date.js
+++ b/src/rules/date.js
@@ -1,11 +1,7 @@
-import { get, isNil } from 'lodash';
+import { get } from 'lodash';
 import moment from 'moment';
 
 export function date(field, value, options) {
-  if (isNil(value) || value === '') {
-    return null;
-  }
-
   if (!moment(value, get(options, 'format'), true).isValid()) {
     return 'date.format';
   }

--- a/src/rules/length.js
+++ b/src/rules/length.js
@@ -1,10 +1,6 @@
 import { get, isNil } from 'lodash';
 
 export function length(field, value, options) {
-  if (isNil(value) || value === '') {
-    return null;
-  }
-
   let min = get(options, 'min');
   let max = get(options, 'max');
 

--- a/src/rules/numeric.js
+++ b/src/rules/numeric.js
@@ -16,10 +16,6 @@ function evaluateMax(value, max) {
 }
 
 export function numeric(field, value, options) {
-  if (!value && parseInt(value, 10) !== 0) {
-    return null;
-  }
-
   const delimiter = get(options, 'delimiter');
   const number = delimiter ? value.replace(delimiter, '.') : value;
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -19,7 +19,7 @@ import { UnknownRuleError } from './errors';
 export default class Validator {
   constructor(config) {
     if (!config) { throw new Error('Missing validator configuration'); }
-    this.config = config;
+    this.config = freeze(config);
     this.errors = {};
   }
 
@@ -55,7 +55,7 @@ export default class Validator {
         const fieldRules = reject(keys(this.config[field]), 'required');
         for (let i = 0; i < fieldRules.length; i++) {
           const ruleName = fieldRules[i];
-          const ruleConfig = this.config[field][ruleName];
+          const ruleConfig = this.getRuleConfig(field, ruleName);
           error = this.validateRule(ruleName, field, value, assign({}, ruleConfig, { values }));
 
           if (error !== null) {
@@ -93,7 +93,7 @@ export default class Validator {
   }
 
   evaluateIf(field, ruleName, options = {}) {
-    const ruleConfig = get(this.config[field], ruleName);
+    const ruleConfig = this.getRuleConfig(field, ruleName);
 
     if (isUndefined(ruleConfig)) {
       return false;
@@ -113,6 +113,10 @@ export default class Validator {
 
   hasRulesForField(field) {
     return this.config.hasOwnProperty(field);
+  }
+
+  getRuleConfig(field, ruleName) {
+    return get(this.config[field], ruleName);
   }
 
   removeError(field) {


### PR DESCRIPTION
This changes the validator to run required first and skip all other
rules if required fails. The error from required will only be reported
if the given field is actually required. We have not found a case were
another validation should fail on an empty value without it being a
required error. Thus, this makes it unnecessary to handle the empty
corner cases in all rules.

BREAKING CHANGE: This will result in rules not being run with empty
values so if there are rules that depends on empty values they would not
work any longer.