### PR TITLE
fix: reset errors between calls to validate

### DIFF
--- a/src/__tests__/validator_tests.js
+++ b/src/__tests__/validator_tests.js
@@ -25,6 +25,13 @@ test('Validator.validate should call validateField', t => {
   t.truthy(validator.validateField.called);
 });
 
+test('Validator.validate should reset errors', t => {
+  const validator = new Validator({ answer: { required: true } });
+  validator.validate(['answer'], { }, {});
+  const errors = validator.validate([], { }, {});
+  t.deepEqual(errors, {});
+});
+
 test('Validator.validate should filter out valid values', t => {
   const validator = new Validator({});
   sinon.stub(validator, 'validateField').returns(null);

--- a/src/validator.js
+++ b/src/validator.js
@@ -28,6 +28,7 @@ export default class Validator {
   }
 
   validate(fields, data) {
+    this.errors = {};
     map(fields, field => this.validateField(field, get(data, field), data));
     return freeze(this.errors);
   }


### PR DESCRIPTION
Remove the errors between subsequent calls to validate.

The validator keeps the errors from a call to validate in the instance
variable errors. This variable aggregated all errors through the
lifetime of the validator, if the error was not removed inside the
validate call.

This change makes the call to validate first remove all errors from the
previous call to the method before it runs the validations.