### PR TITLE
fix: add support of boolean value in "required" validator

### DIFF
--- a/src/rules/__tests__/required_tests.js
+++ b/src/rules/__tests__/required_tests.js
@@ -34,3 +34,8 @@ test('rules.required should return null for number', t => {
 test('rules.required should return null for non-empty-array', t => {
   t.is(required('field', [42]), null);
 });
+
+test('rules.required should return null for boolean values', t => {
+  t.is(required('field', true), null);
+  t.is(required('field', false), null);
+});

--- a/src/rules/required.js
+++ b/src/rules/required.js
@@ -1,4 +1,4 @@
-import { isArray, isEmpty, isString, isNumber } from 'lodash';
+import { isArray, isEmpty, isString, isNumber, isBoolean } from 'lodash';
 
 export default function required(field, value) {
   let result = false;
@@ -9,6 +9,8 @@ export default function required(field, value) {
     result = !isEmpty(value);
   } else if (isNumber(value)) {
     result = !!value.toString();
+  } else if (isBoolean(value)) {
+    return null;
   } else {
     result = !!value;
   }


### PR DESCRIPTION
Fix for https://github.com/cicerono/validator/issues/46

Boolean value should be treated as valid in `required` validator.