### PR TITLE
feat: Add new rule sumArray

### DIFF
--- a/src/rules/__tests__/sumArray_tests.js
+++ b/src/rules/__tests__/sumArray_tests.js
@@ -1,0 +1,54 @@
+import test from 'ava';
+
+import sumArray from '../sumArray';
+
+test('rules.sumArray should return "sumArray.exact" for invalid exact', t => {
+  t.is(sumArray('field', [0, 1, 2], { exact: 4 }), 'sumArray.exact');
+  t.is(sumArray(
+    'field',
+    [{ value: 0 }, { value: 1 }, { value: 2 }],
+    { exact: 4, field: 'value' }
+  ), 'sumArray.exact');
+});
+
+test('rules.sumArray should return "sumArray.min" for invalid min', t => {
+  t.is(sumArray('field', [0], { min: 2, max: 4 }), 'sumArray.min');
+  t.is(sumArray(
+    'field',
+    [{ value: 0 }, { value: 1 }],
+      { min: 2, max: 4, field: 'value' }
+    ), 'sumArray.min');
+});
+
+test('rules.sumArray should return "sumArray.max" for invalid max', t => {
+  t.is(sumArray('field', [0, 1, 4], { min: 2, max: 4 }), 'sumArray.max');
+  t.is(sumArray(
+    'field',
+    [{ value: 0 }, { value: 1 }, { value: 4 }],
+    { min: 2, max: 4, field: 'value' }
+  ), 'sumArray.max');
+});
+
+test('rules.sumArray should return null for unapplicable data type', t => {
+  t.is(sumArray('field', 'value', { exact: 100 }), 'sumArray');
+  t.is(sumArray('field', 123, { exact: 100 }), 'sumArray');
+  t.is(sumArray('field', {}, { exact: 100 }), 'sumArray');
+});
+
+test('rules.sumArray should return null for valid exact', t => {
+  t.is(sumArray('field', [0, 1, 2], { exact: 3 }), null);
+  t.is(sumArray(
+    'field',
+    [{ value: 0 }, { value: 1 }, { value: 2 }],
+    { exact: 3, field: 'value' }
+  ), null);
+});
+
+test('rules.sumArray should return null for valid min/max', t => {
+  t.is(sumArray('field', [0, 1, 2], { min: 2, max: 4 }), null);
+  t.is(sumArray(
+    'field',
+    [{ value: 0 }, { value: 1 }, { value: 2 }],
+    { min: 2, max: 4, field: 'value' }
+  ), null);
+});

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -5,3 +5,4 @@ export { default as length } from './length';
 export { default as numeric } from './numeric';
 export { default as regex } from './regex';
 export { default as required } from './required';
+export { default as sumArray } from './sumArray';

--- a/src/rules/sumArray.js
+++ b/src/rules/sumArray.js
@@ -1,0 +1,50 @@
+
+import { get, isArray, isNil, isObject, reduce } from 'lodash';
+import { isFloat } from 'validator';
+
+function evaluateMin(value, min) {
+  if (isNil(min) || min === '') {
+    return false;
+  }
+  return !isFloat(value.toString(), { min: parseFloat(min) });
+}
+
+function evaluateMax(value, max) {
+  if (isNil(max) || max === '') {
+    return false;
+  }
+  return !isFloat(value.toString(), { max: parseFloat(max) });
+}
+
+export default function sumArray(field, value, options) {
+  if (!isArray(value)) {
+    return 'sumArray';
+  }
+
+  const number = reduce(
+    value,
+    (lastValue, item) => lastValue + parseFloat(isObject(item) ? item[options.field] : item),
+    0
+  );
+
+  if (!isFloat(number.toString())) {
+    return 'sumArray';
+  }
+
+  const exact = get(options, 'exact');
+  if (!isNil(exact) && parseFloat(number) !== parseFloat(exact)) {
+    return 'sumArray.exact';
+  }
+
+  const min = get(options, 'min');
+  if (evaluateMin(number, min)) {
+    return 'sumArray.min';
+  }
+
+  const max = get(options, 'max');
+  if (evaluateMax(number, max)) {
+    return 'sumArray.max';
+  }
+
+  return null;
+}


### PR DESCRIPTION
Usage examples:

    { listOfNumbers: { sumArray: { min: 100, max: 200 } } }
    { listOfObjects: { sumArray: { exact: 100, field: 'percentage' } } }

Fixes #28