### PR TITLE
feat: extend duration rule

### DIFF
--- a/src/rules/__tests__/duration_tests.js
+++ b/src/rules/__tests__/duration_tests.js
@@ -25,20 +25,51 @@ it('duration should validate min value from a field', () => {
   expect(duration('field', {}, { min: { field: 'a' }, values: {} })).toBe(null);
   expect(duration('field', {}, { min: { field: 'a' }, values: { a: null } })).toBe(null);
   expect(duration('field', {}, { min: { field: 'a' }, values: { a: '' } })).toBe(null);
+  expect(duration('field', {}, { min: { field: 'a' }, values: { a: { } } })).toBe(null);
 
-  expect(duration('field', { years: 10 }, { min: { field: 'a' }, values: { a: 120 } }))
+  expect(duration('field', { years: 10 }, { min: { field: 'a' }, values: { a: { years: 10 } } }))
     .toBe(null);
-  expect(duration('field', { months: 10 }, { min: { field: 'a' }, values: { a: 10 } }))
+  expect(duration(
+      'field',
+      { years: 10 },
+      { min: { field: 'a' }, values: { a: { years: 10, months: 0 } } }
+    )).toBe(null);
+  expect(duration('field', { months: 10 }, { min: { field: 'a' }, values: { a: { months: 10 } } }))
     .toBe(null);
-  expect(duration('field', { years: 10, months: 10 }, { min: { field: 'a' }, values: { a: 120 } }))
+  expect(duration(
+      'field',
+      { months: 10 },
+      { min: { field: 'a' }, values: { a: { years: 0, months: 10 } } }
+    )).toBe(null);
+  expect(duration(
+      'field',
+      { years: 10, months: 10 },
+      { min: { field: 'a' }, values: { a: { years: 10, months: 10 } } }
+    )).toBe(null);
+  expect(duration(
+      'field',
+      { years: 10, months: 10 },
+      { min: { field: 'a' }, values: { a: { years: '10', months: '10' } } }
+    )).toBe(null);
+  expect(duration('field', { years: 10 }, { min: { field: '' }, values: { } }))
+    .toBe(null);
+  expect(duration('field', { years: 10 }, { min: { field: undefined }, values: { } }))
+    .toBe(null);
+  expect(duration('field', { years: 10 }, { min: { field: null }, values: { } }))
     .toBe(null);
 
-  expect(duration('field', { years: 10 }, { min: { field: 'a' }, values: { a: 121 } }))
+  expect(duration(
+      'field',
+      { years: 10 },
+      { min: { field: 'a' }, values: { a: { years: 10, months: 11 } } }
+    )).toBe('duration.min.field');
+  expect(duration('field', { months: 10 }, { min: { field: 'a' }, values: { a: { months: 11 } } }))
     .toBe('duration.min.field');
-  expect(duration('field', { months: 10 }, { min: { field: 'a' }, values: { a: 11 } }))
-    .toBe('duration.min.field');
-  expect(duration('field', { years: 10, months: 10 }, { min: { field: 'a' }, values: { a: 131 } }))
-    .toBe('duration.min.field');
+  expect(duration(
+      'field',
+      { years: 10, months: 10 },
+      { min: { field: 'a' }, values: { a: { years: 10, months: 11 } } }
+    )).toBe('duration.min.field');
 });
 
 it('duration should validate max value', () => {
@@ -57,18 +88,55 @@ it('duration should validate max value from a field', () => {
   expect(duration('field', {}, { max: { field: 'a' }, values: {} })).toBe(null);
   expect(duration('field', {}, { max: { field: 'a' }, values: { a: null } })).toBe(null);
   expect(duration('field', {}, { max: { field: 'a' }, values: { a: '' } })).toBe(null);
+  expect(duration('field', {}, { max: { field: 'a' }, values: { a: { } } })).toBe(null);
 
-  expect(duration('field', { years: 10 }, { max: { field: 'a' }, values: { a: 120 } }))
+  expect(duration('field', { years: 10 }, { max: { field: 'a' }, values: { a: { years: 10 } } }))
     .toBe(null);
-  expect(duration('field', { months: 10 }, { max: { field: 'a' }, values: { a: 10 } }))
+  expect(duration(
+      'field',
+      { years: 10 },
+      { max: { field: 'a' }, values: { a: { years: 10, months: 0 } } }
+    )).toBe(null);
+  expect(duration(
+      'field',
+      { months: 10 },
+      { max: { field: 'a' }, values: { a: { months: 10 } } }
+    )).toBe(null);
+  expect(duration(
+      'field',
+      { months: 10 },
+      { max: { field: 'a' }, values: { a: { years: 0, months: 10 } } }
+    )).toBe(null);
+  expect(duration(
+      'field',
+      { years: 10, months: 10 },
+      { max: { field: 'a' }, values: { a: { years: 10, months: 10 } } }
+    )).toBe(null);
+  expect(duration(
+      'field',
+      { years: 10, months: 10 },
+      { max: { field: 'a' }, values: { a: { years: '10', months: '10' } } }
+    )).toBe(null);
+  expect(duration('field', { years: 10 }, { max: { field: '' }, values: { } }))
     .toBe(null);
-  expect(duration('field', { years: 10, months: 10 }, { max: { field: 'a' }, values: { a: 130 } }))
+  expect(duration('field', { years: 10 }, { max: { field: undefined }, values: { } }))
+    .toBe(null);
+  expect(duration('field', { years: 10 }, { max: { field: null }, values: { } }))
     .toBe(null);
 
-  expect(duration('field', { years: 10 }, { max: { field: 'a' }, values: { a: 119 } }))
-    .toBe('duration.max.field');
-  expect(duration('field', { months: 10 }, { max: { field: 'a' }, values: { a: 9 } }))
-    .toBe('duration.max.field');
-  expect(duration('field', { years: 10, months: 10 }, { max: { field: 'a' }, values: { a: 129 } }))
-    .toBe('duration.max.field');
+  expect(duration(
+      'field',
+      { years: 10 },
+      { max: { field: 'a' }, values: { a: { years: 9, months: 11 } } }
+    )).toBe('duration.max.field');
+  expect(duration(
+      'field',
+      { months: 10 },
+      { max: { field: 'a' }, values: { a: { years: 0, months: 9 } } }
+    )).toBe('duration.max.field');
+  expect(duration(
+      'field',
+      { years: 10, months: 10 },
+      { max: { field: 'a' }, values: { a: { years: 10, months: 9 } } }
+    )).toBe('duration.max.field');
 });

--- a/src/rules/duration.js
+++ b/src/rules/duration.js
@@ -4,7 +4,7 @@ import { get, isObject } from 'lodash';
 import { evaluateMin, evaluateMax } from '../utils/numbers';
 import type { RuleOptions } from '../types';
 
-const calculateMonths = (years: number, months: number) => (years * 12) + months;
+const calculateMonths = (years: number = 0, months: number = 0) => (years * 12) + months;
 
 export default function duration(
   field: string,
@@ -18,8 +18,17 @@ export default function duration(
 
   const min = get(options, 'min');
   if (isObject(min)) {
-    if (min.field && evaluateMin(valueInMonths, get(options, `values.${min.field}`))) {
-      return 'duration.min.field';
+    if (min.field) {
+      const refField = get(options, `values.${min.field}`, {});
+      if (evaluateMin(
+        valueInMonths,
+        calculateMonths(
+          parseInt(get(refField, 'years', 0), 10),
+          parseInt(get(refField, 'months', 0), 10)
+        ))
+      ) {
+        return 'duration.min.field';
+      }
     }
   } else {
     if (evaluateMin(valueInMonths, min)) {
@@ -29,8 +38,17 @@ export default function duration(
 
   const max = get(options, 'max');
   if (isObject(max)) {
-    if (max.field && evaluateMax(valueInMonths, get(options, `values.${max.field}`))) {
-      return 'duration.max.field';
+    if (max.field) {
+      const refField = get(options, `values.${max.field}`, {});
+      if (evaluateMax(
+          valueInMonths,
+          calculateMonths(
+            parseInt(get(refField, 'years', 99999), 10),
+            parseInt(get(refField, 'months', 99999), 10)
+          ))
+      ) {
+        return 'duration.max.field';
+      }
     }
   } else {
     if (evaluateMax(valueInMonths, max)) {


### PR DESCRIPTION
we need to support more complex duration rule, what means, we must be able
validate duration format  against another duration format.
Before this change, we have been able to validate {month, years} format against number,
but now, we will be able validate {month, year} against {month, year}