### PR TITLE
fix: Firefox regex issue

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 coverage
+flow-typed

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  node:
+    version: 6
+
+dependencies:
+  pre:
+    - |
+      if [[ ! -e ~/.yarn/bin/yarn ]]; then
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s
+      fi
+    - pip install tox
+  cache_directories:
+    - ~/.yarn
+    - ~/.cache/yarn
+  override:
+    - yarn install
+
+test:
+  override:
+    - npm run lint
+    - npm run flow || true
+    - npm test
+  post:
+    - cp -r coverage $CIRCLE_ARTIFACTS

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:flow": "flow-copy-source src lib && rm -rf lib/**/__tests__",
     "test": "jest --coverage",
     "lint": "eslint .",
+    "flow": "flow check",
     "semantic-release": "false && semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {

--- a/src/rules/__tests__/regex_tests.js
+++ b/src/rules/__tests__/regex_tests.js
@@ -2,18 +2,21 @@
 /* eslint-env jest */
 import regex from '../regex';
 
-it('rules.regex it should return null when the value match the pattern', () => {
-  expect(regex('field', '2013', { pattern: /20\d+\d+/ })).toBe(null);
+describe('rules.regex', () => {
+  it('should return null when the value match the pattern', () => {
+    expect(regex('field', '2013', { pattern: /20\d+\d+/ })).toBe(null);
+  });
+
+  it('should return null when the value match a string pattern', () => {
+    expect(regex('field', '2013', { pattern: '20\\d+\\d+' })).toBe(null);
+  });
+
+  it('should return "regex" when the value does not match the pattern', () => {
+    expect(regex('field', '20a3', { pattern: /20\d+\d+/ })).toBe('regex');
+  });
+
+  it('should return "regex" when the value does not match a string pattern', () => {
+    expect(regex('field', '20a3', { pattern: '20\\d+\\d+/' })).toBe('regex');
+  });
 });
 
-it('rules.regex it should return null when the value match a string pattern', () => {
-  expect(regex('field', '2013', { pattern: '20\\d+\\d+' })).toBe(null);
-});
-
-it('rules.regex it should return "regex" when the value does not match the pattern', () => {
-  expect(regex('field', '20a3', { pattern: /20\d+\d+/ })).toBe('regex');
-});
-
-it('rules.regex it should return "regex" when the value does not match a string pattern', () => {
-  expect(regex('field', '20a3', { pattern: '20\\d+\\d+/' })).toBe('regex');
-});

--- a/src/rules/regex.js
+++ b/src/rules/regex.js
@@ -1,10 +1,8 @@
 // @flow
-import { isString } from 'lodash';
-
 import type { RuleOptions } from '../types';
 
 export default function regex(field: string, value: string, options: RuleOptions): ?string {
-  const pattern = isString(options.pattern) ? new RegExp(options.pattern) : options.pattern;
+  const pattern = new RegExp(options.pattern);
 
   if (!pattern.test(value)) {
     return 'regex';

--- a/src/validator.js
+++ b/src/validator.js
@@ -30,6 +30,7 @@ export default function extend(rules: RuleSet) {
     }
 
     const rule = lookupRule(ruleName);
+    // eslint-disable-next-line no-use-before-define
     const error = rule(field, value, options, validator);
 
     if (error) {


### PR DESCRIPTION
There is an issue where some regexes will trigger an error in firefox when
they are created with the short format /regex/. Wrapping them in new
RegExp() mitigates this issue.